### PR TITLE
Bump Cargo Dependencies

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,4 +1,4 @@
-defmodule FastRss.MixProject do
+defmodule FastRSS.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/avencera/fast_rss"

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule FastRss.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/avencera/fast_rss"
-  @version "0.3.5"
+  @version "0.3.6"
 
   def project do
     [

--- a/native/fastrss/Cargo.lock
+++ b/native/fastrss/Cargo.lock
@@ -11,9 +11,9 @@ dependencies = [
 
 [[package]]
 name = "adler"
-version = "0.2.3"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "autocfg"
@@ -101,9 +101,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
+checksum = "265d751d31d6780a3f956bb5b8022feba2d94eeee5a84ba64f4212eedca42213"
 
 [[package]]
 name = "memchr"
@@ -113,9 +113,9 @@ checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f2d26ec3309788e423cfbf68ad1800f061638098d76a83681af979dc4eda19d"
+checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
 dependencies = [
  "adler",
  "autocfg",
@@ -265,9 +265,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.62"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea1c6153794552ea7cf7cf63b1231a25de00ec90db326ba6264440fa08e31486"
+checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
 dependencies = [
  "itoa",
  "ryu",

--- a/native/fastrss/Cargo.toml
+++ b/native/fastrss/Cargo.toml
@@ -2,7 +2,7 @@
 authors = []
 edition = "2018"
 name = "fastrss"
-version = "0.3.4"
+version = "0.3.6"
 
 [lib]
 crate-type = ["dylib"]

--- a/test/fast_rss_test.exs
+++ b/test/fast_rss_test.exs
@@ -1,8 +1,8 @@
-defmodule FastRssTest do
+defmodule FastRSSTest do
   use ExUnit.Case
-  doctest FastRss
+  doctest FastRSS
 
   test "greets the world" do
-    assert FastRss.hello() == :world
+    assert FastRSS.hello() == :world
   end
 end


### PR DESCRIPTION
- bump Cargo dependencies
- rename `FastRss` to `FastRSS`
- bump version to `0.3.6`