### PR TITLE
Update RSS crate to 2.0.0

### DIFF
--- a/native/fastrss/Cargo.lock
+++ b/native/fastrss/Cargo.lock
@@ -68,9 +68,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.20.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26aab6b48e2590e4a64d1ed808749ba06257882b461d01ca71baeb747074a6dd"
+checksum = "8533f14c8382aaad0d592c812ac3b826162128b65662331e1127b45c3d18536b"
 dependencies = [
  "encoding_rs",
  "memchr",
@@ -87,9 +87,9 @@ dependencies = [
 
 [[package]]
 name = "rss"
-version = "1.10.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e70d6ae72f8a4333af8ce9dce58942020528430eb0d46ee2fcb5e8d4d16377"
+checksum = "36e19e299f301be17927a7c05b8fa1c621e3227e6c3a0da65492701642901ff7"
 dependencies = [
  "quick-xml",
  "serde",

--- a/native/fastrss/Cargo.toml
+++ b/native/fastrss/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/lib.rs"
 
 [dependencies]
 lazy_static = "1.4"
-rss = {version = "1.9", features = ["serde"], default-features = false}
+rss = {version = "2.0", features = ["serde"], default-features = false}
 rustler = "0.23"
 
 serde = "1.0"


### PR DESCRIPTION
## 2.0.0 - 2021-10-21 (from: https://github.com/rust-syndication/rss/blob/master/CHANGELOG.md)

- Disable clock feature of chrono to mitigate RUSTSEC-2020-0159 [`#130`](https://github.com/rust-syndication/rss/pull/130)

- Update quick_xml to 0.22 [`0daf20b`](https://github.com/rust-syndication/rss/commit/0daf20b6f19411450f79090d687d796414193327)

- Fix issues found by clippy [`f3283a1`](https://github.com/rust-syndication/rss/commit/f3283a13808f41f0c10cd64720e493f18a286967)

- Replace HashMap with BTreeMap to have a stable order of tags/attributes [`8b088b1`](https://github.com/rust-syndication/rss/commit/8b088b147c0801a950b5197d6faa475ca766f257)

- Update atom_syndication to 0.10.0 [`975e4aa`](https://github.com/rust-syndication/rss/commit/975e4aa9914985ff4af7ee9834294c15691f0b92)

- Infallible builders [`f736a24`](https://github.com/rust-syndication/rss/commit/f736a2480b3d13114f223048b36f47641bf64858)