### PR TITLE
Update version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ It can be installed by adding `fast_rss` to your list of dependencies in `mix.ex
 ```elixir
 def deps do
   [
-    {:fast_rss, "~> 0.3.4"}
+    {:fast_rss, "~> 0.4.0"}
   ]
 end
 ```


### PR DESCRIPTION
# What 

Update the package version in the installation section of the README.

# Why

This can help save some time for those (like me) that copy/paste the example `deps` listing and don't check what the _actual_ latest version is in `hex`.